### PR TITLE
Feat/cautious optimization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adamw_bf16"
-version = "0.0.3"
+version = "0.1.0"
 authors = [
   { name="APJC", email="apjc@usa.com" },
 ]

--- a/src/adamw_bf16/__init__.py
+++ b/src/adamw_bf16/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 
 __all__ = ["AdamWBF16"]
 


### PR DESCRIPTION
Implement [Cautious Optimization](https://arxiv.org/abs/2411.16085). In conjunction with this repo's implementation of half-precision stochastic rounding, this feature branch improved sample efficiency by 30% in some simple, small-scale SFT experiments I performed with a private training harness on a sequence modeling task. Mask scaling is performed directly against the first-moment estimate rather than the final update.

In AdamW, the entire update rule is:

$$
\theta_{t+1} = \theta_t - \alpha \frac{m_t}{\sqrt{v_t} + \epsilon}
$$

Where:
- $\alpha$ is the learning rate
- $m_t$ is the first-moment estimate
- $v_t$ is the second-moment estimate
- $\epsilon$ is a small constant for numerical stability

If we scale $m_t$ by some constant $c$, we obtain:

$$
\theta_{t+1} = \theta_t - \alpha \frac{c \cdot m_t}{\sqrt{v_t} + \epsilon}
$$

The expression is mathematically equivalent to:

$$
\theta_{t+1} = \theta_t - (c \cdot \alpha) \frac{m_t}{\sqrt{v_t} + \epsilon}
$$

In this case, $c$ represents our element-wise gradient alignment mask from the paper. Hence, this implementation is valid by the distributive property of multiplication over division, as whether we scale $m_t$ directly or the entire update term, we reach the same result